### PR TITLE
fix image token extraction bug

### DIFF
--- a/source/Image.py
+++ b/source/Image.py
@@ -7,7 +7,7 @@ __all__ = ['Image']
 class Image:
     IMAGE_INFO = compile(r'("infoList":\[\{.*?}])')
     IMAGE_TOKEN = compile(
-        r"http://sns-webpic-qc.xhscdn.com/\d+/\w+/(\w+)!")
+        r"http://sns-webpic-qc.xhscdn.com/\d+/\w+/([/\w]+)!")
 
     def get_image_link(self, html: str) -> list:
         data = self.__extract_image_data(html)


### PR DESCRIPTION
cover the corner case: https://www.xiaohongshu.com/explore/6582f9f0000000003802ba2a

The reason why there were bugs before was that the second situation in the picture below was not taken into account.

![image](https://github.com/JoeanAmier/XHS-Downloader/assets/126306048/1a396b42-ff1f-487c-bbfa-b0e7a4268627)

