### PR TITLE
【BUG 修复】从文件头修正不正确的文件名

### DIFF
--- a/source/module/static.py
+++ b/source/module/static.py
@@ -66,3 +66,14 @@ PROGRESS = "b bright_magenta"
 ERROR = "b bright_red"
 WARNING = "b bright_yellow"
 INFO = "b bright_green"
+
+MAGIC_DICT = {
+    # 分别为偏移量(字节)、魔数、后缀名
+    # 参考：https://en.wikipedia.org/wiki/List_of_file_signatures
+    (0, b"\xFF\xD8\xFF", "jpg"),
+    (0, b"\x89\x50\x4E\x47\x0D\x0A\x1A\x0A", "png"),
+    (0, b"\x00\x00\x00", "avif"),
+    (4, b"\x66\x74\x79\x70\x68\x65\x69\x63", "heic"),
+    (8, b"\x57\x45\x42\x50", "webp"),
+}
+FILE_HEADER_MAX_LENGTH = max(offset + len(magic) for offset, magic, _ in MAGIC_DICT)


### PR DESCRIPTION
### BUG 描述

从服务器获取到的文件，其格式不总是请求的格式，且部分文件的响应头的不规范，无法从响应头推测文件的类型。

### 修复

此PR的解决方案为读取文件头，从而解析出文件类型。

当解析失败时，返回预设的文件格式，即维持原有行为

文件头与文件格式的对应关系参考自：<https://www.garykessler.net/library/file_sigs.html>

![image](https://github.com/user-attachments/assets/2176a4b8-2a74-424e-a858-51f583b169e7)

图中测试样例序号为2、3的图片为HEIC格式 链接：https://www.xiaohongshu.com/explore/66d1cbfa000000001d014084
