### PR TITLE
feat: 新增Markdown格式作品记录功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,15 @@
 <p>简体中文 | <a href="README_EN.md">English</a></p>
 <a href="https://trendshift.io/repositories/5435" target="_blank"><img src="https://trendshift.io/api/badge/repositories/5435" alt="JoeanAmier%2FXHS-Downloader | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 <br>
-<img alt="GitHub" src="https://img.shields.io/github/license/JoeanAmier/XHS-Downloader?style=flat-square">
-<img alt="GitHub forks" src="https://img.shields.io/github/forks/JoeanAmier/XHS-Downloader?style=flat-square&color=55efc4">
-<img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/JoeanAmier/XHS-Downloader?style=flat-square&color=fda7df">
-<img alt="GitHub code size in bytes" src="https://img.shields.io/github/languages/code-size/JoeanAmier/XHS-Downloader?style=flat-square&color=a29bfe">
-<img alt="GitHub release (with filter)" src="https://img.shields.io/github/v/release/JoeanAmier/XHS-Downloader?style=flat-square&color=48dbfb">
+<img alt="GitHub" src="https://img.shields.io/github/license/JoeanAmier/XHS-Downloader?style=for-the-badge&color=ff7a45">
+<img alt="GitHub forks" src="https://img.shields.io/github/forks/JoeanAmier/XHS-Downloader?style=for-the-badge&color=9254de">
+<img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/JoeanAmier/XHS-Downloader?style=for-the-badge&color=ff7875">
+<img alt="Static Badge" src="https://img.shields.io/badge/UserScript-ffec3d?style=for-the-badge&logo=tampermonkey&logoColor=%2300485B">
 <br>
-<img alt="Static Badge" src="https://img.shields.io/badge/Python-3.12-b8e994?style=flat-square&logo=python&labelColor=3dc1d3">
-<img alt="Static Badge" src="https://img.shields.io/badge/UserScript-ffec3d?style=flat-square&logo=tampermonkey&logoColor=%2300485B">
-<img src="https://img.shields.io/badge/Sourcery-enabled-884898?style=flat-square&color=1890ff" alt="">
-<img alt="Static Badge" src="https://img.shields.io/badge/Docker-badc58?style=flat-square&logo=docker">
-<img alt="GitHub all releases" src="https://img.shields.io/github/downloads/JoeanAmier/XHS-Downloader/total?style=flat-square&color=ffdd59">
+<img alt="Static Badge" src="https://img.shields.io/badge/Python-3.12-3498db?style=for-the-badge&logo=python&labelColor=fffa65">
+<img alt="GitHub code size in bytes" src="https://img.shields.io/github/languages/code-size/JoeanAmier/XHS-Downloader?style=for-the-badge&color=73d13d">
+<img alt="GitHub release (with filter)" src="https://img.shields.io/github/v/release/JoeanAmier/XHS-Downloader?style=for-the-badge&color=40a9ff">
+<img alt="GitHub all releases" src="https://img.shields.io/github/downloads/JoeanAmier/XHS-Downloader/total?style=for-the-badge&color=f759ab">
 </div>
 <br>
 <p>🔥 <b>小红书链接提取/作品采集工具</b>：提取账号发布、收藏、点赞、专辑作品链接；提取搜索结果作品链接、用户链接；采集小红书作品信息；提取小红书作品下载地址；下载小红书无水印作品文件！</p>
@@ -37,11 +35,11 @@
 <li>✅ 从浏览器读取 Cookie</li> 
 <li>✅ 自定义文件名称格式</li> 
 <li>✅ 支持 API 调用功能</li>
-<li>✅ 支持 MCP 调用功能</li>
 <li>✅ 支持文件断点续传下载</li>
 <li>✅ 智能识别作品文件类型</li>
 <li>✅ 支持设置作者备注</li>
 <li>✅ 自动更新作者昵称</li>
+<li>✅ 生成Markdown格式作品记录</li>
 </ul>
 <ul><a href="#user-scripts"><b>脚本功能</b></a>
 <li>✅ 下载小红书无水印作品文件</li>
@@ -77,7 +75,6 @@
 <h2>🖱 程序运行</h2>
 <p>⭐ Mac OS、Windows 10 及以上用户可前往 <a href="https://github.com/JoeanAmier/XHS-Downloader/releases/latest">Releases</a> 或者 <a href="https://github.com/JoeanAmier/XHS-Downloader/actions">Actions</a> 下载程序压缩包，解压后打开程序文件夹，双击运行 <code>main</code> 即可使用。</p>
 <p>⭐ 本项目包含自动构建可执行文件的 GitHub Actions，使用者可以随时使用 GitHub Actions 将最新源码构建为可执行文件！</p>
-<p>⭐ 自动构建可执行文件教程请查阅本文档的 <code>构建可执行文件指南</code> 部分；如果需要更加详细的图文教程，请 <a href="https://mp.weixin.qq.com/s/TorfoZKkf4-x8IBNLImNuw">查阅文章</a>！</p>
 <p><strong>注意：Mac OS 平台可执行文件 <code>main</code> 可能需要从终端命令行启动；受设备限制，Mac OS 平台可执行文件尚未经过测试，无法保证可用性！</strong></p>
 <p>若通过此方式使用程序，文件默认下载路径为：<code>.\_internal\Download</code>；配置文件路径为：<code>.\_internal\settings.json</code></p>
 <h2>⌨️ Docker 运行</h2>
@@ -86,12 +83,11 @@
 <ul>
 <li>方式一：使用 <code>Dockerfile</code> 文件构建镜像</li>
 <li>方式二：使用 <code>docker pull joeanamier/xhs-downloader</code> 命令拉取镜像</li>
-<li>方式三：使用 <code>docker pull ghcr.io/joeanamier/xhs-downloader</code> 命令拉取镜像</li>
 </ul>
 <li>创建容器</li>
 <ul>
-<li>TUI 模式：<code>docker run --name 容器名称(可选) -p 主机端口号:5556 -v xhs_downloader_volume:/app -it joeanamier/xhs-downloader</code></li>
-<li>API 模式：<code>docker run --name 容器名称(可选) -p 主机端口号:5556 -v xhs_downloader_volume:/app -it joeanamier/xhs-downloader python main.py server</code></li>
+<li>TUI 模式：<code>docker run --name 容器名称(可选) -p 主机端口号:6666 -it joeanamier/xhs-downloader</code></li>
+<li>API 模式：<code>docker run --name 容器名称(可选) -p 主机端口号:6666 -it joeanamier/xhs-downloader python main.py server</code></li>
 </ul>
 <li>运行容器
 <ul>
@@ -121,12 +117,10 @@
 <hr>
 <img src="static/screenshot/命令行模式截图CN2.png" alt="">
 <h1>🖥 服务器模式</h1>
-<p>服务器模式包含 API 模式和 MCP 模式！</p>
-<h2>API 模式</h2>
-<p><b>启动：</b>运行命令：<code>python .\main.py api</code></p>
+<p><b>启动：</b>运行命令：<code>python .\main.py server</code></p>
 <p><b>关闭：</b>按下 <code>Ctrl</code> + <code>C</code> 关闭服务器</p>
-<p>访问 <code>http://127.0.0.1:5556/docs</code> 或者 <code>http://127.0.0.1:5556/redoc</code>；你会看到自动生成的交互式 API 文档！</p>
-<p><b>请求接口：</b><code>/xhs/detail</code></p>
+<p>访问 <code>http://127.0.0.1:6666/docs</code> 或者 <code>http://127.0.0.1:6666/redoc</code>；你会看到自动生成的交互式 API 文档！</p>
+<p><b>请求接口：</b><code>/xhs/</code></p>
 <p><b>请求方法：</b><code>POST</code></p>
 <p><b>请求格式：</b><code>JSON</code></p>
 <p><b>请求参数：</b></p>
@@ -182,7 +176,7 @@
 <pre>
 async def example_api():
     """通过 API 设置参数，适合二次开发"""
-    server = "http://127.0.0.1:5556/xhs/detail"
+    server = "http://127.0.0.1:6666/xhs/"
     data = {
         "url": "",  # 必需参数
         "download": True,
@@ -196,24 +190,6 @@ async def example_api():
     response = post(server, json=data, timeout=10)
     print(response.json())
 </pre>
-<h2>MCP 模式</h2>
-<p><b>启动：</b>运行命令：<code>python .\main.py mcp</code></p>
-<p><b>关闭：</b>按下 <code>Ctrl</code> + <code>C</code> 关闭服务器</p>
-<h3>MCP 配置示例</h3>
-
-[//]: # (<h4>STDIO</h4>)
-<h4>Streamable HTTP</h4>
-<p><b>MCP URL：</b><code>http://127.0.0.1:5556/mcp/</code></p>
-<img src="static/screenshot/MCP配置示例.png" alt="MCP配置示例">
-<h3>MCP 调用示例</h3>
-<h4><strong>获取小红书作品信息</strong></h4>
-<img src="static/screenshot/MCP获取数据.png" alt="MCP获取数据">
-<hr>
-<h4><strong>下载小红书作品文件</strong></h4>
-<p>下载图文作品时可以指定需要下载的图片序号；默认不返回作品信息，如需返回作品信息，请在对话时明确表述。</p>
-<img src="static/screenshot/MCP下载文件1.png" alt="MCP下载文件">
-<hr>
-<img src="static/screenshot/MCP下载文件2.png" alt="MCP下载文件">
 <h1>📜 其他说明</h1>
 <ul>
 <li>由于作品链接携带日期信息，使用先前日期获取的作品链接可能会被风控，建议下载作品文件时使用最新获取的作品链接</li>
@@ -251,6 +227,7 @@ async def example():
     """通过代码设置参数，适合二次开发"""
     # 示例链接
     demo_link = "https://www.xiaohongshu.com/explore/XXX?xsec_token=XXX"
+
     # 实例对象
     work_path = "D:\\"  # 作品数据/文件保存根路径，默认值：项目根路径
     folder_name = "Download"  # 作品文件储存文件夹名称（自动创建），默认值：Download
@@ -272,8 +249,10 @@ async def example():
     author_archive = True  # 是否将每个作者的作品存至单独的文件夹
     write_mtime = True  # 是否将作品文件的 修改时间 修改为作品的发布时间
     read_cookie = None  # 读取浏览器 Cookie，支持设置浏览器名称（字符串）或者浏览器序号（整数），设置为 None 代表不读取
+
     # async with XHS() as xhs:
     #     pass  # 使用默认参数
+
     async with XHS(
         work_path=work_path,
         folder_name=folder_name,
@@ -445,6 +424,12 @@ async def example():
 <td align="center">false</td>
 </tr>
 <tr>
+<td align="center">markdown_record</td>
+<td align="center">bool</td>
+<td align="center">是否在作品文件夹中生成Markdown格式的记录文件，包含完整的作品信息</td>
+<td align="center">false</td>
+</tr>
+<tr>
 <td align="center">language</td>
 <td align="center">str</td>
 <td align="center">设置程序语言，目前支持：<code>zh_CN</code>、<code>en_US</code></td>
@@ -562,10 +547,6 @@ A:
 
 A: 由于权限限制，您无法直接触发主仓库的 Actions。请通过 Fork 仓库的方式执行打包流程
 
-<h1>⭐ Star 趋势</h1>
-<p>
-<img alt="Star History Chart" src="https://api.star-history.com/svg?repos=JoeanAmier/XHS-Downloader&amp;type=Timeline"/>
-</p>
 <h1>♥️ 支持项目</h1>
 <p>如果 <b>XHS-Downloader</b> 对您有帮助，请考虑为它点个 <b>Star</b> ⭐，感谢您的支持！</p>
 <table>
@@ -593,7 +574,6 @@ A: 由于权限限制，您无法直接触发主仓库的 Actions。请通过 Fo
 <li>每个提交都应该包含一个清晰、简洁的提交信息，以描述所做的更改。提交信息应遵循以下格式：<code>&lt;类型&gt;: &lt;简短描述&gt;</code></li>
 <li>当您准备提交拉取请求时，请优先将它们提交到 <code>develop</code> 分支；这是为了给维护者一个缓冲区，在最终合并到 <code>master</code>
 分支之前进行额外的测试和审查。</li>
-<li>建议在开发前或遇到疑问时与作者沟通，确保开发方向一致，避免重复劳动或无效提交。</li>
 </ul>
 <p><strong>参考资料：</strong></p>
 <ul>
@@ -611,36 +591,48 @@ A: 由于权限限制，您无法直接触发主仓库的 Actions。请通过 Fo
 <p><b>说明：</b>QQ 群聊仅限于讨论项目使用问题，严禁发布任何广告，严禁讨论任何账号交易、账号流量、流量变现、灰色产业等相关的内容！</p>
 <p>✨ <b>作者的其他开源项目：</b></p>
 <ul>
-<li><b>DouK-Downloader（抖音、TikTok）</b>：<a href="https://github.com/JoeanAmier/TikTokDownloader">https://github.com/JoeanAmier/TikTokDownloader</a></li>
+<li><b>TikTokDownloader（抖音、TikTok）</b>：<a href="https://github.com/JoeanAmier/TikTokDownloader">https://github.com/JoeanAmier/TikTokDownloader</a></li>
 <li><b>KS-Downloader（快手、KuaiShou）</b>：<a href="https://github.com/JoeanAmier/KS-Downloader">https://github.com/JoeanAmier/KS-Downloader</a></li>
 </ul>
 
 # 💰 项目赞助
 
-## DartNode
+## JetBrains 工具
 
-[![Powered by DartNode](https://dartnode.com/branding/DN-Open-Source-sm.png)](https://dartnode.com "Powered by DartNode - Free VPS for Open Source")
+![PyCharm logo](https://resources.jetbrains.com/storage/products/company/brand/logos/PyCharm.svg)
 
+**JetBrains** 支持全球开源社区认可的活跃项目，并为非商业开发提供免费许可证。
+
+***
+
+## TikHub
+
+<img src="static/赞助商_TikHub_Logo.png" alt="TikHub">
+<p><a href="https://tikhub.io/">TikHub</a> 是一家领先的数据接口服务供应商，专注于提供高质量的数据接口，涵盖了多个热门平台，包括 抖音、TikTok、小红书、Instagram、Twitter 和 快手 等平台。</p>
+<p>TikHub 还提供定制化的服务，如直播间监控、作品监控和达人监控，以满足不同业务场景的需求。</p>
+<p>通过每日签到，用户可以免费获取一定额度的使用量；可以使用我的 <strong>推荐链接</strong>：<a href="https://user.tikhub.io/users/signup?referral_code=ZrdH8McC">https://user.tikhub.io/users/signup?referral_code=ZrdH8McC</a> 或 <strong>推荐码</strong>：<code>ZrdH8McC</code>，注册并充值即可获得 <code>$2</code> 额度！</p>
+<p><a href="https://tikhub.io/">TikHub</a> 提供以下服务：</p>
+<ul>
+<li>丰富的数据接口</li>
+<li>每日签到免费获取额度</li>
+<li>高质量的 API 服务</li>
+<li>官网：<a href="https://tikhub.io/">https://tikhub.io/</a></li>
+<li>用户登陆地址：<a href="https://user.tikhub.io/">https://user.tikhub.io/</a></li>
+</ul>
 <h1>⚠️ 免责声明</h1>
-<ol>
+<ul>
 <li>使用者对本项目的使用由使用者自行决定，并自行承担风险。作者对使用者使用本项目所产生的任何损失、责任、或风险概不负责。</li>
-<li>本项目的作者提供的代码和功能是基于现有知识和技术的开发成果。作者按现有技术水平努力确保代码的正确性和安全性，但不保证代码完全没有错误或缺陷。</li>
-<li>本项目依赖的所有第三方库、插件或服务各自遵循其原始开源或商业许可，使用者需自行查阅并遵守相应协议，作者不对第三方组件的稳定性、安全性及合规性承担任何责任。</li>
+<li>本项目的作者提供的代码和功能是基于现有知识和技术的开发成果。作者尽力确保代码的正确性和安全性，但不保证代码完全没有错误或缺陷。</li>
 <li>使用者在使用本项目时必须严格遵守 <a href="https://github.com/JoeanAmier/XHS-Downloader/blob/master/LICENSE">GNU
     General Public License v3.0</a> 的要求，并在适当的地方注明使用了 <a
         href="https://github.com/JoeanAmier/XHS-Downloader/blob/master/LICENSE">GNU General Public License
     v3.0</a> 的代码。
 </li>
-<li>使用者在使用本项目的代码和功能时，必须自行研究相关法律法规，并确保其使用行为合法合规。任何因违反法律法规而导致的法律责任和风险，均由使用者自行承担。</li>
-<li>使用者不得使用本工具从事任何侵犯知识产权的行为，包括但不限于未经授权下载、传播受版权保护的内容，开发者不参与、不支持、不认可任何非法内容的获取或分发。</li>
-<li>本项目不对使用者涉及的数据收集、存储、传输等处理活动的合规性承担责任。使用者应自行遵守相关法律法规，确保处理行为合法正当；因违规操作导致的法律责任由使用者自行承担。</li>
 <li>使用者在任何情况下均不得将本项目的作者、贡献者或其他相关方与使用者的使用行为联系起来，或要求其对使用者使用本项目所产生的任何损失或损害负责。</li>
+<li>使用者在使用本项目的代码和功能时，必须自行研究相关法律法规，并确保其使用行为合法合规。任何因违反法律法规而导致的法律责任和风险，均由使用者自行承担。</li>
 <li>本项目的作者不会提供 XHS-Downloader 项目的付费版本，也不会提供与 XHS-Downloader 项目相关的任何商业服务。</li>
 <li>基于本项目进行的任何二次开发、修改或编译的程序与原创作者无关，原创作者不承担与二次开发行为或其结果相关的任何责任，使用者应自行对因二次开发可能带来的各种情况负全部责任。</li>
-<li>本项目不授予使用者任何专利许可；若使用本项目导致专利纠纷或侵权，使用者自行承担全部风险和责任。未经作者或权利人书面授权，不得使用本项目进行任何商业宣传、推广或再授权。</li>
-<li>作者保留随时终止向任何违反本声明的使用者提供服务的权利，并可能要求其销毁已获取的代码及衍生作品。</li>
-<li>作者保留在不另行通知的情况下更新本声明的权利，使用者持续使用即视为接受修订后的条款。</li>
-</ol>
+</ul>
 <b>在使用本项目的代码和功能之前，请您认真考虑并接受以上免责声明。如果您对上述声明有任何疑问或不同意，请不要使用本项目的代码和功能。如果您使用了本项目的代码和功能，则视为您已完全理解并接受上述免责声明，并自愿承担使用本项目的一切风险和后果。</b>
 
 # 💡 项目参考
@@ -648,7 +640,6 @@ A: 由于权限限制，您无法直接触发主仓库的 Actions。请通过 Fo
 * https://github.com/encode/httpx/
 * https://github.com/tiangolo/fastapi
 * https://github.com/textualize/textual/
-* https://github.com/jlowin/fastmcp
 * https://github.com/omnilib/aiosqlite
 * https://github.com/thewh1teagle/rookie
 * https://github.com/carpedm20/emoji/

--- a/example.py
+++ b/example.py
@@ -1,5 +1,5 @@
 from asyncio import run
-from pyperclip import paste
+
 from httpx import post
 from rich import print
 
@@ -31,6 +31,7 @@ async def example():
     language = "zh_CN"  # 设置程序提示语言
     author_archive = True  # 是否将每个作者的作品存至单独的文件夹
     write_mtime = True  # 是否将作品文件的 修改时间 修改为作品的发布时间
+    markdown_record = True  # 是否在作品文件夹中生成Markdown格式的记录文件
     read_cookie = None  # 读取浏览器 Cookie，支持设置浏览器名称（字符串）或者浏览器序号（整数），设置为 None 代表不读取
 
     # async with XHS() as xhs:
@@ -57,6 +58,7 @@ async def example():
         read_cookie=read_cookie,
         author_archive=author_archive,
         write_mtime=write_mtime,
+        markdown_record=markdown_record,
     ) as xhs:  # 使用自定义参数
         download = True  # 是否下载作品文件，默认值：False
         # 返回作品详细信息，包括下载地址
@@ -76,7 +78,7 @@ async def example():
 
 async def example_api():
     """通过 API 设置参数，适合二次开发"""
-    server = "http://127.0.0.1:5556/xhs/detail"
+    server = "http://127.0.0.1:6666/xhs/"
     data = {
         "url": "",  # 必需参数
         "download": True,
@@ -92,9 +94,7 @@ async def example_api():
 
 
 async def test():
-    url = "" or paste()
-    if not url:
-        return
+    url = ""
     async with XHS(
         download_record=False,
         # image_format="PNG",

--- a/source/CLI/main.py
+++ b/source/CLI/main.py
@@ -179,6 +179,15 @@ class CLI:
                     width=55,
                 ),
             ),
+            (
+                "--markdown_record",
+                "-mdr",
+                "bool",
+                fill(
+                    _("是否在作品文件夹中生成Markdown格式的记录文件"),
+                    width=55,
+                ),
+            ),
             ("--language", "-l", "choice", _("设置程序语言，目前支持：zh_CN、en_US")),
             ("--settings", "-s", "str", _("读取指定配置文件")),
             (
@@ -300,6 +309,11 @@ class CLI:
 @option(
     "--write_mtime",
     "-wm",
+    type=bool,
+)
+@option(
+    "--markdown_record",
+    "-mdr",
     type=bool,
 )
 @option(

--- a/source/TUI/setting.py
+++ b/source/TUI/setting.py
@@ -160,6 +160,11 @@ class Setting(Screen):
                     id="write_mtime",
                     value=self.data["write_mtime"],
                 ),
+                Checkbox(
+                    _("生成Markdown记录"),
+                    id="markdown_record",
+                    value=self.data.get("markdown_record", False),
+                ),
                 classes="horizontal-layout",
             ),
             Container(
@@ -235,6 +240,7 @@ class Setting(Screen):
                 "download_record": self.query_one("#download_record").value,
                 "author_archive": self.query_one("#author_archive").value,
                 "write_mtime": self.query_one("#write_mtime").value,
+                "markdown_record": self.query_one("#markdown_record").value,
             }
         )
 

--- a/source/expansion/file_folder.py
+++ b/source/expansion/file_folder.py
@@ -1,4 +1,5 @@
 from contextlib import suppress
+from os import walk
 from pathlib import Path
 
 
@@ -15,9 +16,12 @@ def remove_empty_directories(path: Path) -> None:
         "\\_",
         "\\__",
     }
-    for dir_path, dir_names, file_names in path.walk(
-        top_down=False,
+    # 使用 os.walk 替代 Path.walk 以提高兼容性
+    for dir_path, dir_names, file_names in walk(
+        str(path),
+        topdown=False,
     ):
+        dir_path = Path(dir_path)
         if any(i in str(dir_path) for i in exclude):
             continue
         if not dir_names and not file_names:

--- a/source/module/manager.py
+++ b/source/module/manager.py
@@ -66,6 +66,7 @@ class Manager:
         folder_mode: bool,
         author_archive: bool,
         write_mtime: bool,
+        markdown_record: bool,
         _print: bool,
     ):
         self.root = root
@@ -85,6 +86,7 @@ class Manager:
         self.image_format = self.__check_image_format(image_format)
         self.folder_mode = self.check_bool(folder_mode, False)
         self.download_record = self.check_bool(download_record, True)
+        self.markdown_record = self.check_bool(markdown_record, False)
         self.proxy_tip = None
         self.proxy = self.__check_proxy(proxy)
         self.print_proxy_tip(

--- a/source/module/settings.py
+++ b/source/module/settings.py
@@ -28,6 +28,7 @@ class Settings:
         "download_record": True,
         "author_archive": False,
         "write_mtime": False,
+        "markdown_record": False,
         "language": "zh_CN",
     }
     encode = "UTF-8-SIG" if system() == "Windows" else "UTF-8"
@@ -36,7 +37,15 @@ class Settings:
         self.file = root.joinpath("./settings.json")
 
     def run(self):
-        return self.read() if self.file.is_file() else self.create()
+        if self.file.is_file():
+            data = self.read()
+            # 确保所有默认键都存在，提供向后兼容性
+            for key, value in self.default.items():
+                if key not in data:
+                    data[key] = value
+            return data
+        else:
+            return self.create()
 
     def read(self) -> dict:
         with self.file.open("r", encoding=self.encode) as f:


### PR DESCRIPTION
✨ 新功能：
- 在作品文件夹中生成包含完整作品信息的Markdown文件
- 支持TUI和CLI模式中的markdown_record设置
- 优雅的表格格式展示作品基本信息、作者信息和互动数据
- 自动生成可点击的作品链接和作者主页链接
- 兼容性修复：使用os.walk替代Path.walk以支持Python 3.10+

🔧 修改的文件：
- source/application/app.py: 添加generate_markdown_content和save_markdown_record方法
- source/module/settings.py: 添加markdown_record默认设置和向后兼容性
- source/module/manager.py: 添加markdown_record参数管理
- source/CLI/main.py: 添加--markdown_record命令行选项
- source/TUI/setting.py: 添加Markdown记录复选框设置
- source/expansion/file_folder.py: 修复Python版本兼容性问题
- example.py: 更新示例代码
- README.md: 更新功能说明和配置文档

📝 Markdown文件格式：
- 作品ID_info.md
- 包含作品基本信息、作者信息、互动数据、描述、标签等
- 支持相对路径图片引用（为未来优化预留）