### PR TITLE
chore(cli): remove stale browser cookie path

### DIFF
--- a/source/CLI/main.py
+++ b/source/CLI/main.py
@@ -17,8 +17,6 @@ from rich.panel import Panel
 from rich.table import Table
 
 from source.application import XHS
-
-# from source.expansion import BrowserCookie
 from source.module import (
     ROOT,
     PROJECT,
@@ -72,14 +70,7 @@ class CLI:
             return ROOT
         return s.parent if (s := Root(self.path)).is_file() else ROOT
 
-    @staticmethod
-    def __merge_cookie(data: dict) -> None:
-        if not data["cookie"] and (bc := data["browser_cookie"]):
-            data["cookie"] = bc
-        data.pop("browser_cookie")
-
     def __clean_params(self, data: dict) -> dict:
-        # self.__merge_cookie(data)
         return {k: v for k, v in data.items() if v != None}
 
     @staticmethod
@@ -98,16 +89,6 @@ class CLI:
     def version(ctx: Context, param, value) -> None:
         echo(PROJECT)
         ctx.exit()
-
-    # @staticmethod
-    # @check_value
-    # def read_cookie(ctx: Context, param, value) -> str:
-    #     return BrowserCookie.get(
-    #         value,
-    #         domains=[
-    #             "xiaohongshu.com",
-    #         ],
-    #     )
 
     @staticmethod
     @check_value
@@ -184,25 +165,6 @@ class CLI:
             ),
             ("--language", "-l", "choice", _("设置程序语言，目前支持：zh_CN、en_US")),
             ("--settings", "-s", "str", _("读取指定配置文件")),
-            # (
-            #     "--browser_cookie",
-            #     "-bc",
-            #     "choice",
-            #     fill(
-            #         _(
-            #             "从指定的浏览器读取小红书网页版 Cookie，支持：{0}; 输入浏览器名称或序号"
-            #         ).format(
-            #             ", ".join(
-            #                 f"{i}: {j}"
-            #                 for i, j in enumerate(
-            #                     BrowserCookie.SUPPORT_BROWSER.keys(),
-            #                     start=1,
-            #                 )
-            #             )
-            #         ),
-            #         width=55,
-            #     ),
-            # ),
             ("--update_settings", "-us", "flag", _("是否更新配置文件")),
             ("--help", "-h", "flag", _("查看详细参数说明")),
             ("--version", "-v", "flag", _("查看 XHS-Downloader 版本")),
@@ -327,15 +289,6 @@ class CLI:
     "-s",
     type=Path(dir_okay=False),
 )
-# @option(
-#     "--browser_cookie",
-#     "-bc",
-#     type=Choice(
-#         list(BrowserCookie.SUPPORT_BROWSER.keys())
-#         + [str(i) for i in range(1, len(BrowserCookie.SUPPORT_BROWSER) + 1)]
-#     ),
-#     callback=CLI.read_cookie,
-# )
 @option(
     "--update_settings",
     "-us",


### PR DESCRIPTION
﻿## Summary

- Remove the unused browser_cookie merge helper and its commented CLI option remnants.
- Keep the supported --cookie parameter unchanged.

## Why

browser_cookie is no longer registered as a CLI option. The former merge helper directly indexed that removed parameter, which caused the V2.7 KeyError reported in #341. Current master no longer invokes the helper, but retaining the unreachable and unsafe compatibility path makes accidental re-enablement error-prone.

## Validation

- python -m compileall -q source/CLI/main.py
- Verified Click still registers cookie and does not register browser_cookie.
- Verified browser_cookie no longer appears in source/CLI/main.py.
- git diff --check

## Notes

ruff check source/CLI/main.py still reports pre-existing E711 and F402 findings on untouched lines; this PR does not introduce or alter them.

## Summary by Sourcery

移除已弃用的 browser cookie CLI 路径及其合并辅助逻辑，同时保持现有 `--cookie` 选项的行为不变。

Bug Fixes:
- 删除不安全的 `browser_cookie` 合并逻辑，该逻辑在 `browser_cookie` 参数缺失时可能会触发 `KeyError`。

Enhancements:
- 从 CLI 入口点中清理所有剩余的与 `browser_cookie` 相关的导入、回调和选项定义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the deprecated browser cookie CLI path and its merge helper while keeping the existing --cookie option behavior unchanged.

Bug Fixes:
- Eliminate the unsafe browser_cookie merge logic that could raise KeyError when the browser_cookie parameter is absent.

Enhancements:
- Clean up all remaining browser_cookie-related imports, callbacks, and option definitions from the CLI entry point.

</details>

Bug 修复：
- 删除不安全的 `browser_cookie` 合并逻辑，以避免在缺少 `browser_cookie` 参数时导致 `KeyError`。

增强内容：
- 从 CLI 入口中清理所有与 `browser_cookie` 相关的已注释导入、回调以及选项定义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

移除已弃用的 browser cookie CLI 路径及其合并辅助逻辑，同时保持现有 `--cookie` 选项的行为不变。

Bug Fixes:
- 删除不安全的 `browser_cookie` 合并逻辑，该逻辑在 `browser_cookie` 参数缺失时可能会触发 `KeyError`。

Enhancements:
- 从 CLI 入口点中清理所有剩余的与 `browser_cookie` 相关的导入、回调和选项定义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the deprecated browser cookie CLI path and its merge helper while keeping the existing --cookie option behavior unchanged.

Bug Fixes:
- Eliminate the unsafe browser_cookie merge logic that could raise KeyError when the browser_cookie parameter is absent.

Enhancements:
- Clean up all remaining browser_cookie-related imports, callbacks, and option definitions from the CLI entry point.

</details>

</details>