### PR TITLE
fix: 优先下载 H.264 视频，避免 HEVC 只有声音

### DIFF
--- a/source/application/video.py
+++ b/source/application/video.py
@@ -27,6 +27,22 @@ class Video:
             else []
         )
 
+    @staticmethod
+    def is_h264(item: Namespace) -> bool:
+        codec = str(getattr(item, "videoCodec", "")).lower()
+        desc = str(getattr(item, "streamDesc", "")).lower()
+        try:
+            stream_type = int(getattr(item, "streamType", 0))
+        except (TypeError, ValueError):
+            stream_type = 0
+        # 小红书登录页面返回的流使用 EF4/EF5 这类编码标识。
+        # EF4 对应 H.264/AVC，EF5 对应 H.265/HEVC；streamType 258/259 等小于 300 的也属于 AVC。
+        return (
+            codec in {"h264", "avc1", "x264", "ef4"}
+            or "x264" in desc
+            or 0 < stream_type < 300
+        )
+
     @classmethod
     def get_video_link(
         cls,
@@ -35,6 +51,9 @@ class Video:
     ) -> list:
         if not (items := cls.get_video_items(data)):
             return []
+        # Prefer H.264/AVC to avoid HEVC playback issues (audio only).
+        if compatible := [item for item in items if cls.is_h264(item)]:
+            items = compatible
         match preference:
             case "resolution":
                 items.sort(key=lambda x: x.height)

--- a/static/XHS-Downloader.js
+++ b/static/XHS-Downloader.js
@@ -597,6 +597,14 @@ Discord Community: https://discord.com/invite/ZYtmgKud9Y
             const key = note.video?.consumer?.originVideoKey;
             if (key) return [`https://sns-video-bd.xhscdn.com/${key}`];
             const allStreams = Object.values(note.video.media.stream).flat();
+            const avcStreams = allStreams.filter(stream =>
+                ["h264", "avc1", "x264", "EF4"].includes(stream.videoCodec) ||
+                (stream.streamType && stream.streamType < 300)
+            );
+            if (avcStreams.length) {
+                sortArray(avcStreams, "height");
+                return [avcStreams[0].backupUrls[0] || avcStreams[0].masterUrl];
+            }
             sortArray(allStreams, "height");
             return [allStreams[0].backupUrls[0] || allStreams[0].masterUrl];
         } catch (error) {


### PR DESCRIPTION
解决了一下，下载视频时候只有音频信息

## Summary by Sourcery

优先下载 H.264/AVC 视频流以提升播放兼容性并避免音视频不完整。

Bug Fixes:
- 优先选择 H.264/AVC 视频流，避免下载 HEVC 视频时出现只有音频的问题。

Enhancements:
- 统一在 Python 和前端视频链接选择逻辑中筛选并优先使用兼容性更好的 AVC 流。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优先下载 H.264/AVC 视频流以提升播放兼容性并避免音视频不完整。

Bug Fixes:
- 优先选择 H.264/AVC 视频流，避免下载 HEVC 视频时出现只有音频的问题。

Enhancements:
- 统一在 Python 和前端视频链接选择逻辑中筛选并优先使用兼容性更好的 AVC 流。

</details>